### PR TITLE
[WIP] introduce disposal of components at release time

### DIFF
--- a/src/net40/Radical.Windows.Presentation.Autofac/Services/ComponentReleaser.cs
+++ b/src/net40/Radical.Windows.Presentation.Autofac/Services/ComponentReleaser.cs
@@ -8,18 +8,23 @@ using Topics.Radical.Windows.Presentation.ComponentModel;
 
 namespace Topics.Radical.Windows.Presentation.Services
 {
-	class ComponentReleaser : IReleaseComponents
-	{
-		readonly IContainer container;
+    class ComponentReleaser : IReleaseComponents
+    {
+        readonly IContainer container;
 
-		public ComponentReleaser( IContainer container )
-		{
-			this.container = container;
-		}
+        public ComponentReleaser( IContainer container )
+        {
+            this.container = container;
+        }
 
-		public void Release( object component )
-		{
-			//NOP
-		}
-	}
+        public void Release( object component )
+        {
+            //NOP
+            var disposable = component as IDisposable;
+            if(disposable != null)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
 }


### PR DESCRIPTION
WIP : Do not merge.

This is the second option to address https://github.com/RadicalFx/Radical/issues/20, this is problematic since at this level we have no idea of what is going to be released, that means that if the incoming component is a singleton we should do nothing, but we have no easy way to handle that scenario. So I'm :-1: to this approach in favor of https://github.com/RadicalFx/Radical.Windows.Presentation/pull/34

Connected to https://github.com/RadicalFx/Radical/issues/20
